### PR TITLE
Adding Node version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "start": "node src/index.js"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "author": "your-name",
   "license": "ISC",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
+// This will check if the node version you are running is the required
+// Node version or higher, if it isn't it will throw the following error to inform you.
+if (Number(process.version.slice(1).split(".")[0]) < 12) throw new Error("Node 12.0.0 or higher is required. You need to update your Node.js to the required release, or a newer one.");
+
 // First, we require discord.js's Client and Collection constructors
 const { Client, Collection } = require("discord.js")
 // Now, we initialize a new discord.js Client


### PR DESCRIPTION
With the latest v12 release of the Discord.js library, they bumped to Node.js v12, and stopped supporting older releases. Using an older release will not work, and most likely throw up numerous errors. So, I added a version check to the main file, and package.json.